### PR TITLE
Rename `Preferences` to `Settings`

### DIFF
--- a/SponsorBlock for YouTube - Skip Sponsorships/Shared (App)/Base.lproj/Main.html
+++ b/SponsorBlock for YouTube - Skip Sponsorships/Shared (App)/Base.lproj/Main.html
@@ -19,13 +19,13 @@
     </p>
     <p class="platform-ios">You can turn on SponsorBlock’s Safari extension in Settings.</p>
     <img class="platform-ios" src="../ios_instructions.png"/>
-    <p class="platform-mac state-unknown">You can turn on SponsorBlock’s extension in Safari Extensions preferences.</p>
+    <p class="platform-mac state-unknown">You can turn on SponsorBlock’s extension in Safari Extensions settings.</p>
 
-    <p class="platform-mac state-on">SponsorBlock’s extension is currently on. You can turn it off in Safari Extensions preferences.</p>
-    <p class="platform-mac state-off">SponsorBlock’s extension is currently off. You can turn it on in Safari Extensions preferences.</p>
-    <p class="platform-mac">If SponsorBlock is missing from the Safari Extensions preferences, see <a href="https://github.com/ajayyy/SponsorBlock/issues/827#issuecomment-998585411">this comment</a> for a solution.</a></p>
+    <p class="platform-mac state-on">SponsorBlock’s extension is currently on. You can turn it off in Safari Extensions settings.</p>
+    <p class="platform-mac state-off">SponsorBlock’s extension is currently off. You can turn it on in Safari Extensions settings.</p>
+    <p class="platform-mac">If SponsorBlock is missing from the Safari Extensions settings, see <a href="https://github.com/ajayyy/SponsorBlock/issues/827#issuecomment-998585411">this comment</a> for a solution.</a></p>
     
-    <button class="platform-mac open-preferences">Quit and Open Safari Extensions Preferences…</button>
+    <button class="platform-mac open-preferences">Quit and Open Safari Extensions Settings…</button>
     
     <p>
         Join us on the <a href="https://discord.gg/SponsorBlock" target="_blank">Discord</a> or <a href="https://matrix.to/#/#sponsor:ajay.app" target="_blank">Matrix</a> chats.


### PR DESCRIPTION
`Preferences` became `Settings` in macOS Ventura: https://9to5mac.com/2022/11/01/mac-system-settings-macos-ventura/